### PR TITLE
Release 1.0.5 with updated kubernetes-client 6.8.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.mics21"
-version = "1.0.4"
+version = "1.0.5"
 
 repositories {
     gradlePluginPortal()
@@ -19,7 +19,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
 
-    implementation("io.fabric8:kubernetes-client:6.0.0")
+    implementation("io.fabric8:kubernetes-client:6.8.1")
 
 }
 
@@ -48,6 +48,6 @@ pluginBundle {
     mavenCoordinates {
         groupId = "io.github.mics21"
         artifactId = "local-infra-plugin"
-        version = "1.0.4"
+        version = "1.0.5"
     }
 }

--- a/src/main/kotlin/LocalInfra.kt
+++ b/src/main/kotlin/LocalInfra.kt
@@ -1,7 +1,7 @@
 package io.github.mics21.localInfraPlugin
 
 import io.fabric8.kubernetes.client.Config
-import io.fabric8.kubernetes.client.DefaultKubernetesClient
+import io.fabric8.kubernetes.client.KubernetesClientBuilder
 import org.gradle.api.Project
 import java.io.File
 import java.sql.DriverManager
@@ -93,8 +93,8 @@ private fun getHostForNameMapping(envName: String, serviceName: String,kubeconfi
     }
 }
 private fun kubeClient(kubeconfigPath: String?)=kubeconfigPath?.let {
-    DefaultKubernetesClient(Config.fromKubeconfig(File(it).readText()))
-}?:DefaultKubernetesClient()
+    KubernetesClientBuilder().withConfig(Config.fromKubeconfig(File(it).readText())).build()
+}?:KubernetesClientBuilder().build()
 
 internal fun Project.stopLocalInfra(projectName: String) {
     if (currentRunningComposeProject() == null) {


### PR DESCRIPTION
Closes #2 

Update kubernetes-client from version 6.0.0 to 6.8.1 to additionally support kubernetes versions 1.25 to 1.27

Use KubernetesClientBuilder instead of deprecated direct use of DefaultKubernetesClient

Update release


